### PR TITLE
Added installation note for Windows

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.rust-lang.org

--- a/css/style.css
+++ b/css/style.css
@@ -1,11 +1,28 @@
 body {
 	margin-top: 30px;
+	margin-bottom: 60px;
+}
+p {
+	margin-top: 1.2em;
+	margin-bottom: 1.2em;
+}
+li {
+	margin-top: 1em;
+	margin-bottom: 1em;
+}
+h1.title {
+	font-size: 2.5em;
+	margin-top: 1em;
+	font-weight: normal;
+	margin-bottom: 10px;
+}
+h1 {
+	font-size: 2em;
+	margin-top: 1.2em;
+	margin-bottom: 0.5em;
 }
 h1 small {
 	color: #777;
-}
-p {
-	margin: 20px 0;
 }
 
 ul.menu {
@@ -15,6 +32,8 @@ ul.menu {
 }
 ul.menu li {
 	list-style-type: none;
+	margin-top: 0em;
+	margin-bottom: 0em;
 }
 ul.menu h2 {
 	font-size: 1.1em;
@@ -27,11 +46,33 @@ ul.menu li>ul {
 	line-height: 1.5em;
 }
 
-.col-md-2 h2 {
+.note {
+	font-style: italic;
+}
+
+.side-header h2 {
 	font-weight: bold;
 	font-size: 1.1em;
 	line-height: 24px;
 	margin-top: 7px;
+}
+
+.side-header h3 {
+	font-size: 1em;
+	margin-top: 0px;
+}
+
+.side-header p {
+	color: 	#777;
+}
+
+.preferred-method h2 {
+	font-weight: bold;
+	font-size: 1.1em;
+	line-height: 24px;
+	display: inline;
+	margin-right: 0.5em;
+	margin-top: 0px;
 }
 
 .table-features {
@@ -44,6 +85,41 @@ ul.menu li>ul {
 .table-features td {
 	padding: 6px 12px;
 	border: none;
+}
+
+.install-menu {
+	margin-top: 5em;
+}
+
+.install-menu .row {
+	margin-bottom: 1.5em;
+}
+
+.table-installers {
+	margin-left: 2em;
+	width: 30em;
+	border-spacing: 2px;
+	border: 0px;
+	empty-cells: hide;
+}
+
+.table-installers td {
+	border: 1px solid #ddd;
+	text-align: center;
+	border-radius: 4px;
+}
+
+.table-installers td.inst-type {
+	border: 0px;
+	font-weight: bold;
+	text-align: left;
+	width: 15em;
+}
+
+.table-installers td div {
+	height: 100%;
+	width: 100%;
+	border: 2px solid green;
 }
 
 @media (min-width: 992px) {

--- a/css/style.css
+++ b/css/style.css
@@ -11,10 +11,14 @@ li {
 	margin-bottom: 1em;
 }
 h1.title {
-	font-size: 2.5em;
-	margin-top: 1em;
-	font-weight: normal;
+	font-size: 3em;
+	margin-top: 0.5em;
+	font-weight: bold;
 	margin-bottom: 10px;
+	text-align: center;
+}
+h1.title span {
+	font-size: 70%;
 }
 h1 {
 	font-size: 2em;
@@ -23,6 +27,7 @@ h1 {
 }
 h1 small {
 	color: #777;
+	margin-left: 1em;
 }
 
 ul.menu {
@@ -39,6 +44,7 @@ ul.menu h2 {
 	font-size: 1.1em;
 	font-weight: bold;
 	margin: 0;
+	margin-bottom: 1em;
 }
 ul.menu li>ul {
 	margin-top: .5em;
@@ -46,13 +52,26 @@ ul.menu li>ul {
 	line-height: 1.5em;
 }
 
+.header-right {
+	text-align: right;
+}
+
+.menu img {
+	margin: 0em auto 0em 0em;
+}
+
 .note {
 	font-style: italic;
 }
 
+h2 {
+	font-weight: bold;
+	font-size: 1.3em;
+}
+
 .side-header h2 {
 	font-weight: bold;
-	font-size: 1.1em;
+	font-size: 1.3em;
 	line-height: 24px;
 	margin-top: 7px;
 }
@@ -78,8 +97,8 @@ ul.menu li>ul {
 .table-features {
 	width: 100%;
 	margin-bottom: 18px;
-	border: 1px solid #ddd;
-	border-radius: 4px;
+	border: 1px solid #ccc;
+	border-radius: 3px;
 	border-collapse: inherit;
 }
 .table-features td {
@@ -98,15 +117,13 @@ ul.menu li>ul {
 .table-installers {
 	margin-left: 2em;
 	width: 30em;
-	border-spacing: 2px;
+	border-spacing: 4px;
 	border: 0px;
 	empty-cells: hide;
 }
 
 .table-installers td {
-	border: 1px solid #ddd;
-	text-align: center;
-	border-radius: 4px;
+	padding: 0px;
 }
 
 .table-installers td.inst-type {
@@ -116,10 +133,132 @@ ul.menu li>ul {
 	width: 15em;
 }
 
-.table-installers td div {
-	height: 100%;
-	width: 100%;
-	border: 2px solid green;
+.table-installers div.inst-button {
+	border: 1px solid #ccc;
+	text-align: center;
+	border-radius: 3px;
+	padding: 0.3em;
+}
+
+.table-installers div.inst-button:hover {
+	border-color: #428BCA;
+	color: white;
+	background-color: #428BCA;
+}
+
+.table-installers a {
+	text-decoration: none;
+}
+
+#install-row {
+	margin-bottom: 0em;
+}
+
+#pitch p {
+	margin-top: 2em;
+	margin-bottom: 2em;
+	text-align: left;
+	font-size: 200%;
+}
+
+#install-box {
+	color: #777;
+	text-align: right;
+	font-size: 130%;
+	margin-top: 1em;
+}
+
+#install-box .install-button-row {
+	margin: 1em auto 1em auto;
+}
+
+.version-rec-box {
+	width: 10em;
+	display: inline-block;
+}
+
+.version-rec-box-inner {
+	font-size: 60%;
+	text-align: center;
+}
+
+#install-button {
+	border: 2px solid white;
+	color: white;
+	background-color: #428BCA;
+	border-radius: 4px;
+	padding: 0.5em 0em 0.5em 0em;
+	font-weight: bold;
+	width: 10em;
+	display: inline-block;
+}
+
+#install-button div {
+	text-align: center;
+	
+}
+
+#install-button:hover {
+	border-color: #428BCA;
+	background-color: white;
+	color: #428BCA;
+}
+
+.minor-button {
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	width: 10em;
+	display: inline-block;
+	padding: 0.5em 0em 0.5em 0em;
+}
+
+.minor-button div {
+	text-align: center;
+}
+
+.minor-button:hover {
+	color: white;
+	background-color: #428BCA;
+	border-color: #428BCA;
+}
+
+hr {
+	margin-top: 2em;
+	margin-bottom: 3em;
+}
+
+.asterisk {
+	margin-left: 0px;
+	color: #428BCA;
+}
+
+.footnote {
+	color: #777;
+	text-align: right;
+	font-size: 80%;
+	margin-top: 7em;
+}
+
+.slogan-row {
+	text-align: center;
+	margin-top: 2em;
+	margin-bottom: 4em;
+	font-size: 110%;
+	font-style: italic;
+	height: 2em;
+}
+
+.slogan-row .flowers {
+	color: #428BCA;
+	font-size: 250%;
+	margin: 0px;
+	margin-top: 0.15em;
+}
+
+.laundry-list span.z {
+	color: #428BCA;
+	margin: 0em 0.4em 0em 0em;
+	font-size: 150%;
 }
 
 @media (min-width: 992px) {

--- a/css/style.css
+++ b/css/style.css
@@ -172,6 +172,10 @@ h2 {
 	margin: 1em auto 1em auto;
 }
 
+#install-box .install-note {
+	font-size: 55%;
+}
+
 .version-rec-box {
 	width: 10em;
 	display: inline-block;

--- a/index.html
+++ b/index.html
@@ -18,39 +18,26 @@
 
 		<ul class="row menu">
 			<li class="col-xs-2 col-md-2">
-				<img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" />
+				<a href="index.html"><img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" /></a>
 			</li>
-			<li class="col-xs-2 col-md-2"><h2>Getting Started</h2>
+			<li class="col-xs-2 col-md-2"></li>
+			<li class="col-xs-2 col-md-2"><h2>Docs (Nightly)</h2>
 				<ul>
-					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a> (nightly)</li>
-					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a> (nightly)</li>
-					<li><a href="http://doc.rust-lang.org/doc/0.9/tutorial.html">Tutorial</a> (0.9)</li>
-					<li><a href="http://doc.rust-lang.org/doc/0.9/rust.html">Manual</a> (0.9)</li>
-				</ul>
-			</li>
-			<li class="col-xs-2 col-md-2"><h2>Documentation</h2>
-				<ul>
+					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a></li>
+					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a></li>
 					<li>
-						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
-						<a href="http://static.rust-lang.org/doc/master/index.html">all docs</a> (nightly)
-					</li>
-					<li>
-						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
-						<a href="http://static.rust-lang.org/doc/0.9/index.html">all docs</a> (0.9)
+						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std API docs</a></li>
+						<li><a href="http://static.rust-lang.org/doc/master/index.html">All docs</a>
 					</li>
 				</ul>
 			</li>
-			<li class="col-xs-2 col-md-2"><h2>Downloads</h2>
+			<li class="col-xs-2 col-md-2"><h2>Docs (0.10)</h2>
 				<ul>
+					<li><a href="http://doc.rust-lang.org/doc/0.10/tutorial.html">Tutorial</a></li>
+					<li><a href="http://doc.rust-lang.org/doc/0.10/rust.html">Manual</a></li>
 					<li>
-						0.9 - Jan. 9, 2014
-					</li>
-					<li>
-						<a href="http://static.rust-lang.org/dist/rust-0.9.tar.gz">Source</a>
-						(<a href="https://github.com/mozilla/rust/blob/0.9/RELEASES.txt">release notes</a>)
-					</li>
-					<li>
-						<a href="install.html">Installers</a>
+						<a href="http://doc.rust-lang.org/doc/0.10/std/index.html">std API docs</a></li>
+						<li><a href="http://static.rust-lang.org/doc/0.10/index.html">All docs</a>
 					</li>
 				</ul>
 			</li>
@@ -63,10 +50,10 @@
 						<a href="http://reddit.com/r/rust">Reddit</a> | <a href="http://twitter.com/rustlang">Twitter</a>
 					</li>
 					<li>
-						<a href="https://mail.mozilla.org/listinfo/rust-dev">rust-dev</a> mailing list
+						<a href="https://mail.mozilla.org/listinfo/rust-dev">Mailing List</a>
 					</li>
 					<li>
-						<a href="http://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">#rust on irc.mozilla.org</a>
+						<a href="http://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">IRC</a>
 					</li>
 				</ul>
 			</li>
@@ -74,46 +61,125 @@
 
 		<!-- header end -->
 
-		<div>
-			<h1 class="title">Rust <small>a safe, concurrent, practical language</small></h1>
+
+		<div class="row" id="install-row">
+		  <div class="col-md-8" id="pitch">
+			<!--<p>
+The <b>Rust</b> programming language applies the best
+of modern theory to the problems that face developers
+at the lowest levels of the software stack.
+With Rust, developers may craft systems that coax
+the maximum performance and predictability from tomorrow's hardware.
+And Rust never crashes. <span class="asterisk">*</span>
+			</p>-->
+
 			<p>
-				Rust is a curly-brace, block-structured expression language.
-				It visually resembles the C language family, but differs 
-				significantly in syntactic and semantic details.
-				Its design is oriented toward concerns of “programming in the
-				large”, that is, of creating and maintaining <em>boundaries</em>
-				– both abstract and operational – that preserve large-system <em>
-				integrity</em>, <em>availability</em> and <em>concurrency</em>.
-			</p>
-			<p>
-				It supports a mixture of imperative procedural, concurrent
-				actor, object-oriented and pure functional styles. Rust also
-				supports generic programming and metaprogramming, in both
-				static and dynamic styles.
+			  <b>Rust</b> is a systems programming language
+			  that runs blazingly fast,
+			  prevents all crashes<span class="asterisk">*</span>,
+			  and eliminates data races.
 			</p>
 
-			<div class="row">
-				<div class="col-md-2 side-header">
-					<h2>A short summary of features</h2>
-				</div>
-				<div class="col-md-10">
-					<table class="table-features table-hover"><tbody>
-						<tr><td>Type system</td><td>static, nominal, linear, algebraic, locally inferred</td></tr>
-						<tr><td>Memory safety</td><td>no null or dangling pointers, no buffer overflows</td></tr>
-						<tr><td>Concurrency</td><td>lightweight tasks with message passing, no shared memory</td></tr>
-						<tr><td>Generics</td><td>type parametrization with type classes</td></tr>
-						<tr><td>Exception handling</td><td>unrecoverable unwinding with task isolation</td></tr>
-						<tr><td>Memory model</td><td>optional task-local GC, safe pointer types with region analysis</td></tr>
-						<tr><td>Compilation model</td><td>ahead-of-time, C/C++ compatible</td></tr>
-						<tr><td>License</td><td>dual MIT / Apache 2</td></tr>
-					</tbody></table>
-				</div>
+			<!--<div class="row slogan-row">
+			  <div class="col-md-3"></div>
+			  <div class="col-md-1"><div class="flowers">~</div></div>
+			  <div class="col-md-4">
+				Rust combines<br>high-level convenience<br>with low-level control.
+			  </div>
+			  <div class="col-md-1"><div class="flowers">~</div></div>
+			  <div class="col-md-3"></div>
+			</div>-->
+
+			<!-- FIXME would be nice if all of these were links to docs -->
+			<!--<div class="row laundry-list">
+			  <div class="col-md-6">
+				<div><span class="z">·</span>algebraic data types</div>
+				<div><span class="z">·</span>pattern matching</div>
+				<div><span class="z">·</span>closures</div>
+				<div><span class="z">·</span>type inference</div>
+				<div><span class="z">·</span>built for concurrency</div>
+			  </div>
+			  <div class="col-md-6">
+				<div><span class="z">·</span>zero-cost abstractions</div>
+				<div><span class="z">·</span>guaranteed memory safety</div>
+				<div><span class="z">·</span>no data races</div>
+				<div><span class="z">·</span>minimal runtime</div>
+				<div><span class="z">·</span>efficient FFI</div>
+			  </div>
+			</div>-->
+
+          </div>
+		  <div class="col-md-4">
+			<div id="install-box">
+			  <div class="install-button-row">
+				<span class="version-rec-box">
+				  <span class="version-rec-box-inner">
+					<div>
+					  Recommended Version:
+					</div>
+					<div id="install-version">
+					  0.10-pre-nightly
+					  (<span>source</span>)
+					</div>
+				</span>
+				</span>
+			  </div>
+			  <div class="install-button-row"><a id="inst-link" href="http://static.rust-lang.org/dist/rust-nightly.tar.gz"><span id="install-button"><div>Install</div></span></a></div>
+			  <div class="install-button-row"><a href="install.html"><span class="minor-button"><div>Other Downloads</div></span></a></div>
 			</div>
-			<div class="row">
-				<div class="col-md-2 side-header">
-					<h2>A very small taste of what it looks like</h2>
-				</div>
-				<div class="col-md-10">
+		  </div>
+		</div>
+
+		<div class="row code-row">
+		  <div class="col-md-4">
+			<h2>Featuring</h2>
+			<div class="laundry-list">
+			  <div><span class="z">·</span>algebraic data types</div>
+			  <div><span class="z">·</span>pattern matching</div>
+			  <div><span class="z">·</span>closures</div>
+			  <div><span class="z">·</span>type inference</div>
+			  <div><span class="z">·</span>built for concurrency</div>
+			  <div><span class="z">·</span>zero-cost abstractions</div>
+			  <div><span class="z">·</span>guaranteed memory safety</div>
+			  <div><span class="z">·</span>no data races</div>
+			  <div><span class="z">·</span>minimal runtime</div>
+			  <div><span class="z">·</span>efficient FFI</div>
+			</div>
+		  </div>
+		  <div class="col-md-8">
+<pre class='rust'>
+<span class='kw'>fn</span> main() {
+    <span class='comment'>// A simple integer calculator:
+    // `+` or `-` means add/sub by 1
+    // `*` or `/` means mul/div by 2</span>
+ 
+    <span class='kw'>let</span> program = <span class='string'>"+ + * - /"</span>;
+    <span class='kw'>let</span> <span class='kw'>mut</span> accumulator = <span class='number'>0</span>;
+ 
+    <span class='kw'>for</span> token in program.chars() {
+        <span class='kw'>match</span> token {
+            <span class='string'>'+'</span> => accumulator <span class='op'>+=</span> <span class='number'>1</span>,
+            <span class='string'>'-'</span> => accumulator <span class='op'>-=</span> <span class='number'>1</span>,
+            <span class='string'>'*'</span> => accumulator <span class='op'>*=</span> <span class='number'>2</span>,
+            <span class='string'>'/'</span> => accumulator <span class='op'>/=</span> <span class='number'>2</span>,
+            _ => { <span class='comment'>/* ignore everything else */</span> }
+        }
+    }
+ 
+    <span class='prelude-val'>println!</span>(<span class='string'>"The program \"{}\" calculates the value {}"</span>,
+             program, accumulator);
+}
+</pre>
+		  </div>
+
+
+<!--		<div class="row code-row">
+		  <div class="col-md-3 sample-side">
+			<p>
+			  It looks like languages you are familiar with.
+			</p>
+		  </div>
+		  <div class="col-md-9">
 <pre class='rust'>
 <span class='kw'>fn</span> <span class='ident'>main</span>() {
     <span class='kw'>let</span> <span class='ident'>nums</span> <span class='op'>=</span> [<span class='number'>1</span>, <span class='number'>2</span>];
@@ -128,8 +194,86 @@
     }
 }
 </pre>
-				</div>
-			</div>
+		  </div>
+		</div>-->
+
+
+<!--		  <div class="col-md-10">
+<pre class='rust'>
+<span class='kw'>fn</span> <span class='ident'>main</span>() {
+    <span class='kw'>let</span> <span class='ident'>nums</span> <span class='op'>=</span> [<span class='number'>1</span>, <span class='number'>2</span>];
+    <span class='kw'>let</span> <span class='ident'>noms</span> <span class='op'>=</span> [<span class='string'>&quot;Tim&quot;</span>, <span class='string'>&quot;Eston&quot;</span>, <span class='string'>&quot;Aaron&quot;</span>, <span class='string'>&quot;Ben&quot;</span>];
+
+    <span class='kw'>let</span> <span class='kw-2'>mut</span> <span class='ident'>odds</span> <span class='op'>=</span> <span class='ident'>nums</span>.<span class='ident'>iter</span>().<span class='ident'>map</span>(<span class='op'>|</span><span class='kw-2'>&amp;</span><span class='ident'>x</span><span class='op'>|</span> <span class='ident'>x</span> <span class='op'>*</span> <span class='number'>2</span> <span class='op'>-</span> <span class='number'>1</span>);
+
+    <span class='kw'>for</span> <span class='ident'>num</span> <span class='kw'>in</span> <span class='ident'>odds</span> {
+        <span class='ident'>spawn</span>(<span class='kw'>proc</span>() {
+            <span class='macro'>println</span><span class='macro'>!</span>(<span class='string'>&quot;{:s} says hello from a lightweight thread!&quot;</span>, <span class='ident'>noms</span>[<span class='ident'>num</span>]);
+        });
+    }
+}
+</pre>
+		  </div>-->
+
+		<div class="row">
+		  <div class="col-md-7"></div>
+		  <div class="col-md-5">
+			<p class="footnote">
+			  <span class="asterisk">*</span>
+			  In theory. Rust is still experimental and may do anything it likes up to and including eating your laundry.
+			</p>
+		  </div>
 		</div>
+
 	</body>
+
+    <script type="text/javascript">
+      function detect_platform() {
+          var os = "unknown";
+
+          if (os == "unknown") {
+              if (navigator.platform == "Linux x86_64") os = "x86_64-unknown-linux-gnu";
+              if (navigator.platform == "Linux i686") os = "i686-unknown-linux-gnu";
+          }
+
+          // Still haven't figured it out. Try harder.
+          if (os == "unknown") {
+              if (navigator.appVersion.indexOf("Win")!=-1) os = "i686-pc-mingw32";
+              if (navigator.appVersion.indexOf("Mac")!=-1) os = "x86_64-apple-darwin";
+              if (navigator.appVersion.indexOf("Linux")!=-1) os = "x86_64-unknown-linux-gnu";
+          }
+
+          return os;
+      }
+      
+      var platform = detect_platform();
+
+      var rec_package_name = "nightly";
+      var rec_version_type = "source";
+      var rec_download_file = "rust-nightly.tar.gz";
+
+      if (platform == "x86_64-unknown-linux-gnu") {
+          rec_version_type = "Linux binary";
+          rec_download_file = "rust-" + rec_package_name + "-x86_64-unknown-linux-gnu.tar.gz";
+      } else if (platform == "i686-unknown-linux-gnu") {
+          rec_version_type = "Linux binary";
+          rec_download_file = "rust-" + rec_package_name + "-i686-unknown-linux-gnu.tar.gz";
+      } else if (platform == "x86_64-apple-darwin") {
+          rec_version_type = "Mac installer";
+          rec_download_file = "rust-" + rec_package_name + "-x86_64-apple-darwin.pkg";
+      } else if (platform == "i686-pc-mingw32") {
+          rec_version_type = "Windows installer";
+          rec_download_file = "rust-" + rec_package_name + "-install.exe";
+      }
+
+      var rec_package_desc = rec_package_name + " (<span>" + rec_version_type + "</span>)";
+      var rec_vers_div = document.getElementById("install-version");
+      rec_vers_div.innerHTML = rec_package_desc;
+
+      var rec_dl_addy = "http://static.rust-lang.org/dist/" + rec_download_file;
+      var rec_inst_link = document.getElementById("inst-link");
+      rec_inst_link.setAttribute("href", rec_dl_addy);
+     
+	</script>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -11,14 +11,19 @@
 
 	<body class="container">
 		<a href="//github.com/mozilla/rust"><img class="ribbon" style="display: none" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+
+		<!-- header start -->
+		<!-- HEY! This code is duplicated in the other html files.
+			 That sucks, but if need to change this do some copying and pasting. -->
+
 		<ul class="row menu">
 			<li class="col-xs-2 col-md-2">
 				<img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" />
 			</li>
 			<li class="col-xs-2 col-md-2"><h2>Getting Started</h2>
 				<ul>
-					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a> (master)</li>
-					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a> (master)</li>
+					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a> (nightly)</li>
+					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a> (nightly)</li>
 					<li><a href="http://doc.rust-lang.org/doc/0.9/tutorial.html">Tutorial</a> (0.9)</li>
 					<li><a href="http://doc.rust-lang.org/doc/0.9/rust.html">Manual</a> (0.9)</li>
 				</ul>
@@ -27,14 +32,11 @@
 				<ul>
 					<li>
 						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
-						<a href="http://static.rust-lang.org/doc/master/index.html">all docs</a> (master)
+						<a href="http://static.rust-lang.org/doc/master/index.html">all docs</a> (nightly)
 					</li>
 					<li>
 						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
-						<a href="http://doc.rust-lang.org/doc/0.9/extra/index.html">extra</a> (0.9)
-					</li>
-					<li>
-						<a href="http://static.rust-lang.org/doc/0.9/index.html">All docs</a> (0.9)
+						<a href="http://static.rust-lang.org/doc/0.9/index.html">all docs</a> (0.9)
 					</li>
 				</ul>
 			</li>
@@ -44,14 +46,11 @@
 						0.9 - Jan. 9, 2014
 					</li>
 					<li>
-						<a href="http://static.rust-lang.org/dist/rust-0.9.tar.gz">.tar.gz</a> |
-						<a href="https://github.com/mozilla/rust/wiki/Using-Rust-on-Windows">.exe</a>
+						<a href="http://static.rust-lang.org/dist/rust-0.9.tar.gz">Source</a>
+						(<a href="https://github.com/mozilla/rust/blob/0.9/RELEASES.txt">release notes</a>)
 					</li>
 					<li>
-						<a href="https://github.com/mozilla/rust/blob/0.9/RELEASES.txt">Release notes</a>
-					</li>
-					<li>
-						<a href="https://github.com/mozilla/rust/wiki/Doc-releases">Previous releases</a>
+						<a href="install.html">Installers</a>
 					</li>
 				</ul>
 			</li>
@@ -72,8 +71,11 @@
 				</ul>
 			</li>
 		</ul>
+
+		<!-- header end -->
+
 		<div>
-			<h1>Rust <small>a safe, concurrent, practical language</small></h1>
+			<h1 class="title">Rust <small>a safe, concurrent, practical language</small></h1>
 			<p>
 				Rust is a curly-brace, block-structured expression language.
 				It visually resembles the C language family, but differs 
@@ -91,7 +93,7 @@
 			</p>
 
 			<div class="row">
-				<div class="col-md-2">
+				<div class="col-md-2 side-header">
 					<h2>A short summary of features</h2>
 				</div>
 				<div class="col-md-10">
@@ -108,7 +110,7 @@
 				</div>
 			</div>
 			<div class="row">
-				<div class="col-md-2">
+				<div class="col-md-2 side-header">
 					<h2>A very small taste of what it looks like</h2>
 				</div>
 				<div class="col-md-10">

--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@ And Rust never crashes. <span class="asterisk">*</span>
 				</span>
 				</span>
 			  </div>
-			  <div class="install-button-row"><a id="inst-link" href="http://static.rust-lang.org/dist/rust-nightly.tar.gz"><span id="install-button"><div>Install</div></span></a></div>
+			  <div class="install-button-row"><a id="inst-link" href="http://static.rust-lang.org/dist/rust-nightly.tar.gz"><span id="install-button"><div>Install</div></span></a><div class="install-note"><a href="https://github.com/mozilla/rust/wiki/Using-Rust-on-Windows">* Read before installing on Windows</a></div></div>
 			  <div class="install-button-row"><a href="install.html"><span class="minor-button"><div>Other Downloads</div></span></a></div>
 			</div>
 		  </div>

--- a/install.html
+++ b/install.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>The Rust Programming Language - Installation</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="keywords" content="Rust, Rust programming language, rustlang, Mozilla Rust">
+		<link rel="stylesheet" href="css/bootstrap.min.css">
+		<link rel="stylesheet" href="css/style.css">
+	</head>
+
+	<body class="container">
+
+		<!-- header start -->
+		<!-- HEY! This code is duplicated in the other html files.
+			 That sucks, but if need to change this do some copying and pasting. -->
+
+		<ul class="row menu">
+			<li class="col-xs-2 col-md-2">
+				<img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" />
+			</li>
+			<li class="col-xs-2 col-md-2"><h2>Getting Started</h2>
+				<ul>
+					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a> (nightly)</li>
+					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a> (nightly)</li>
+					<li><a href="http://doc.rust-lang.org/doc/0.9/tutorial.html">Tutorial</a> (0.9)</li>
+					<li><a href="http://doc.rust-lang.org/doc/0.9/rust.html">Manual</a> (0.9)</li>
+				</ul>
+			</li>
+			<li class="col-xs-2 col-md-2"><h2>Documentation</h2>
+				<ul>
+					<li>
+						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
+						<a href="http://static.rust-lang.org/doc/master/index.html">all docs</a> (nightly)
+					</li>
+					<li>
+						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
+						<a href="http://static.rust-lang.org/doc/0.9/index.html">all docs</a> (0.9)
+					</li>
+				</ul>
+			</li>
+			<li class="col-xs-2 col-md-2"><h2>Downloads</h2>
+				<ul>
+					<li>
+						0.9 - Jan. 9, 2014
+					</li>
+					<li>
+						<a href="http://static.rust-lang.org/dist/rust-0.9.tar.gz">Source</a>
+						(<a href="https://github.com/mozilla/rust/blob/0.9/RELEASES.txt">release notes</a>)
+					</li>
+					<li>
+						<a href="install.html">Installers</a>
+					</li>
+				</ul>
+			</li>
+			<li class="col-xs-2 col-md-2"><h2>Community</h2>
+				<ul>
+					<li>
+						<a href="http://github.com/mozilla/rust">GitHub</a>
+					</li>
+					<li>
+						<a href="http://reddit.com/r/rust">Reddit</a> | <a href="http://twitter.com/rustlang">Twitter</a>
+					</li>
+					<li>
+						<a href="https://mail.mozilla.org/listinfo/rust-dev">rust-dev</a> mailing list
+					</li>
+					<li>
+						<a href="http://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">#rust on irc.mozilla.org</a>
+					</li>
+				</ul>
+			</li>
+		</ul>
+
+		<!-- header end -->
+
+		<div class="install-menu">
+		  <div class="row">
+			<div class="col-md-1"></div>
+
+			<div class="col-md-3 side-header">
+			  <h2>Nightly</h2>
+
+			  <p>
+				The current dev branch.
+				It's got all the best stuff and is usually reliable.
+				Many people prefer running nightlies to stay current with Rust as it matures.
+			  </p>
+			</div>
+			<div class="col-md-7">
+			  
+			  <table class="table-features table-installers"><tbody>
+				  <tr>
+					<td class="inst-type">Linux binaries (.tar.gz)</td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz">64-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-unknown-linux-gnu.tar.gz">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Mac installer (.pkg)</td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg">64-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.pkg">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Mac binaries (.tar.gz)</td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz">64-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.tar.gz">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Windows installer (.exe)</td>
+					<td></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-install.exe">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Source</td>
+					<td colspan="2"><a href="http://static.rust-lang.org/dist/rust-nightly.tar.gz">rust-nightly.tar.gz</a></td>
+				  </tr>
+			  </tbody></table>
+			</div>
+
+			<div class="col-md-1"></div>
+
+		  </div>
+
+		  <div class="row">
+
+			<div class="col-md-1"></div>
+
+			<div class="col-md-3 side-header">
+			  <h2>0.10-pre</h2>
+			  <h3>January 9, 2014</h3>
+
+			  <p>
+				The latest release.
+				These are made roughly every three months and tend to become out of date quickly.
+			  </p>
+			</div>
+			<div class="col-md-7">
+			  
+			  <table class="table-features table-installers"><tbody>
+				  <tr>
+					<td class="inst-type">Linux binaries (.tar.gz)</td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-x86_64-unknown-linux-gnu.tar.gz">64-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-i686-unknown-linux-gnu.tar.gz">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Mac installer (.pkg)</td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-x86_64-apple-darwin.pkg">64-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-i686-apple-darwin.pkg">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Mac binaries (.tar.gz)</td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-x86_64-apple-darwin.tar.gz">64-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-i686-apple-darwin.tar.gz">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Windows installer (.exe)</td>
+					<td></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-install.exe">32-bit</a></td>
+				  </tr>
+				  <tr>
+					<td class="inst-type">Source</td>
+					<td colspan="2"><a href="http://static.rust-lang.org/dist/rust-0.10-pre.tar.gz">rust-0.10-pre.tar.gz</a></td>
+				  </tr>
+			  </tbody></table>
+			</div>
+
+			<div class="col-md-1"></div>
+
+		  </div>
+
+		</div>
+		
+		<div class="row">
+		  <div class="col-md-1"></div>
+
+		  <div class="col-md-11">
+			<p>
+			  <a href="https://github.com/mozilla/rust/wiki/Doc-releases">
+				Additional resources
+			  </a>, including release notes, signatures, previous releases.
+			</p>
+          </div>
+		</div>
+
+	</body>
+
+</html>

--- a/install.html
+++ b/install.html
@@ -163,6 +163,9 @@
 
 		  <div class="col-md-11">
 			<p>
+				Note for Windows users: Please read <a href="https://github.com/mozilla/rust/wiki/Using-Rust-on-Windows">Using Rust on Windows</a> before installing.
+			</p>
+			<p>
 			  <a href="https://github.com/mozilla/rust/wiki/Doc-releases">
 				Additional resources
 			  </a>, including release notes, signatures, previous releases.

--- a/install.html
+++ b/install.html
@@ -10,6 +10,7 @@
 	</head>
 
 	<body class="container">
+		<a href="//github.com/mozilla/rust"><img class="ribbon" style="display: none" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
 
 		<!-- header start -->
 		<!-- HEY! This code is duplicated in the other html files.
@@ -17,39 +18,26 @@
 
 		<ul class="row menu">
 			<li class="col-xs-2 col-md-2">
-				<img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" />
+				<a href="index.html"><img class="img-responsive" src="logos/rust-logo-128x128-blk-v2.png" height="128" width="128" alt="Rust logo" /></a>
 			</li>
-			<li class="col-xs-2 col-md-2"><h2>Getting Started</h2>
+			<li class="col-xs-2 col-md-2"></li>
+			<li class="col-xs-2 col-md-2"><h2>Docs (Nightly)</h2>
 				<ul>
-					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a> (nightly)</li>
-					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a> (nightly)</li>
-					<li><a href="http://doc.rust-lang.org/doc/0.9/tutorial.html">Tutorial</a> (0.9)</li>
-					<li><a href="http://doc.rust-lang.org/doc/0.9/rust.html">Manual</a> (0.9)</li>
-				</ul>
-			</li>
-			<li class="col-xs-2 col-md-2"><h2>Documentation</h2>
-				<ul>
+					<li><a href="http://doc.rust-lang.org/doc/master/tutorial.html">Tutorial</a></li>
+					<li><a href="http://doc.rust-lang.org/doc/master/rust.html">Manual</a></li>
 					<li>
-						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std</a> |
-						<a href="http://static.rust-lang.org/doc/master/index.html">all docs</a> (nightly)
-					</li>
-					<li>
-						<a href="http://doc.rust-lang.org/doc/0.9/std/index.html">std</a> |
-						<a href="http://static.rust-lang.org/doc/0.9/index.html">all docs</a> (0.9)
+						<a href="http://doc.rust-lang.org/doc/master/std/index.html">std API docs</a></li>
+						<li><a href="http://static.rust-lang.org/doc/master/index.html">All docs</a>
 					</li>
 				</ul>
 			</li>
-			<li class="col-xs-2 col-md-2"><h2>Downloads</h2>
+			<li class="col-xs-2 col-md-2"><h2>Docs (0.10)</h2>
 				<ul>
+					<li><a href="http://doc.rust-lang.org/doc/0.10/tutorial.html">Tutorial</a></li>
+					<li><a href="http://doc.rust-lang.org/doc/0.10/rust.html">Manual</a></li>
 					<li>
-						0.9 - Jan. 9, 2014
-					</li>
-					<li>
-						<a href="http://static.rust-lang.org/dist/rust-0.9.tar.gz">Source</a>
-						(<a href="https://github.com/mozilla/rust/blob/0.9/RELEASES.txt">release notes</a>)
-					</li>
-					<li>
-						<a href="install.html">Installers</a>
+						<a href="http://doc.rust-lang.org/doc/0.10/std/index.html">std API docs</a></li>
+						<li><a href="http://static.rust-lang.org/doc/0.10/index.html">All docs</a>
 					</li>
 				</ul>
 			</li>
@@ -62,10 +50,10 @@
 						<a href="http://reddit.com/r/rust">Reddit</a> | <a href="http://twitter.com/rustlang">Twitter</a>
 					</li>
 					<li>
-						<a href="https://mail.mozilla.org/listinfo/rust-dev">rust-dev</a> mailing list
+						<a href="https://mail.mozilla.org/listinfo/rust-dev">Mailing List</a>
 					</li>
 					<li>
-						<a href="http://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">#rust on irc.mozilla.org</a>
+						<a href="http://chat.mibbit.com/?server=irc.mozilla.org&amp;channel=%23rust">IRC</a>
 					</li>
 				</ul>
 			</li>
@@ -82,8 +70,7 @@
 
 			  <p>
 				The current dev branch.
-				It's got all the best stuff and is usually reliable.
-				Many people prefer running nightlies to stay current with Rust as it matures.
+				This is the most up to date version with the latest bug fixes and features.
 			  </p>
 			</div>
 			<div class="col-md-7">
@@ -91,27 +78,27 @@
 			  <table class="table-features table-installers"><tbody>
 				  <tr>
 					<td class="inst-type">Linux binaries (.tar.gz)</td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz">64-bit</a></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-unknown-linux-gnu.tar.gz">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz"><div class="inst-button">64-bit</div></a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-unknown-linux-gnu.tar.gz"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Mac installer (.pkg)</td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg">64-bit</a></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.pkg">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.pkg"><div class="inst-button">64-bit</div></a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Mac binaries (.tar.gz)</td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz">64-bit</a></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.tar.gz">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Windows installer (.exe)</td>
 					<td></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-nightly-install.exe">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-nightly-install.exe"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Source</td>
-					<td colspan="2"><a href="http://static.rust-lang.org/dist/rust-nightly.tar.gz">rust-nightly.tar.gz</a></td>
+					<td colspan="2"><a href="http://static.rust-lang.org/dist/rust-nightly.tar.gz"><div class="inst-button">rust-nightly.tar.gz</div></a></td>
 				  </tr>
 			  </tbody></table>
 			</div>
@@ -120,17 +107,19 @@
 
 		  </div>
 
+		  <hr/>
+
 		  <div class="row">
 
 			<div class="col-md-1"></div>
 
 			<div class="col-md-3 side-header">
-			  <h2>0.10-pre</h2>
-			  <h3>January 9, 2014</h3>
+			  <h2>0.10</h2>
+			  <h3>April 3, 2014</h3>
 
 			  <p>
 				The latest release.
-				These are made roughly every three months and tend to become out of date quickly.
+				These are made roughly every three months and become out of date quickly.
 			  </p>
 			</div>
 			<div class="col-md-7">
@@ -138,27 +127,27 @@
 			  <table class="table-features table-installers"><tbody>
 				  <tr>
 					<td class="inst-type">Linux binaries (.tar.gz)</td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-x86_64-unknown-linux-gnu.tar.gz">64-bit</a></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-i686-unknown-linux-gnu.tar.gz">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-x86_64-unknown-linux-gnu.tar.gz"><div class="inst-button">64-bit</div></a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-i686-unknown-linux-gnu.tar.gz"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Mac installer (.pkg)</td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-x86_64-apple-darwin.pkg">64-bit</a></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-i686-apple-darwin.pkg">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.pkg"><div class="inst-button">64-bit</div></a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.pkg"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Mac binaries (.tar.gz)</td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-x86_64-apple-darwin.tar.gz">64-bit</a></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-i686-apple-darwin.tar.gz">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-x86_64-apple-darwin.tar.gz"><div class="inst-button">64-bit</div></a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-i686-apple-darwin.tar.gz"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Windows installer (.exe)</td>
 					<td></td>
-					<td><a href="http://static.rust-lang.org/dist/rust-0.10-pre-install.exe">32-bit</a></td>
+					<td><a href="http://static.rust-lang.org/dist/rust-0.10-install.exe"><div class="inst-button">32-bit</div></a></td>
 				  </tr>
 				  <tr>
 					<td class="inst-type">Source</td>
-					<td colspan="2"><a href="http://static.rust-lang.org/dist/rust-0.10-pre.tar.gz">rust-0.10-pre.tar.gz</a></td>
+					<td colspan="2"><a href="http://static.rust-lang.org/dist/rust-0.10.tar.gz"><div class="inst-button">rust-0.10.tar.gz</div></a></td>
 				  </tr>
 			  </tbody></table>
 			</div>


### PR DESCRIPTION
Added installation note for Windows on the main page and the downloads page pointing to https://github.com/mozilla/rust/wiki/Using-Rust-on-Windows
