### PR TITLE
Revisit various FAQ entries

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -700,7 +700,7 @@ Over time more and more answers will be offered for the current version, thus im
 
 ### How can I make an HTTP request?
 
-[Hyper](https://github.com/hyperium/hyper) is the most popular, but there are [a number of others as well](https://crates.io/keywords/http).
+The standard library does not include an implementation of HTTP, so you will want to use an external crate. [Hyper](https://github.com/hyperium/hyper) is the most popular, but there are [a number of others as well](https://crates.io/keywords/http).
 
 ### How can I write a GUI application in Rust?
 

--- a/faq.md
+++ b/faq.md
@@ -637,7 +637,7 @@ pub fn f() {
 
 In the first example, the module is defined in the same file it's used. In the second example, the module declaration in the main file tells the compiler to look for either `hello.rs` or `hello/mod.rs`, and to load that file.
 
-A `use`ing declaration just tells the compiler to bring everything from a particular module into the current module. Without a `mod` declaration first, the compiler doesn't know if the `use`d module exists, and so can't import its contents into the current module.
+Note the difference between `mod` and `use`: `mod` declares that a module exists, whereas `use` references a module declared elsewhere, bringing its contents into scope within the current module.
 
 ### How do I configure Cargo to use a proxy?
 

--- a/faq.md
+++ b/faq.md
@@ -335,13 +335,27 @@ You need to ensure that the borrowed item will outlive the function. This can be
 
 To return a closure from a function, it must be a "move closure", meaning that the closure is declared with the `move` keyword. As [explained in the Rust book](https://doc.rust-lang.org/book/closures.html#move-closures), this gives the closure its own copy of the captured variables, independent of its parent stack frame. Otherwise, returning a closure would be unsafe, as it would allow access to variables that are no longer valid; put another way: it would allow reading potentially invalid memory. The closure must also be wrapped in a `Box`, so that it is allocated on the heap. Read more about this [in the book](https://doc.rust-lang.org/book/closures.html#returning-closures).
 
-### When are lifetimes required to be defined?
+### Why do some references have lifetimes, like `&'a T`, and some do not, like `&T`?
 
-Lifetimes can often be elided, as explained in the ["Lifetime elision" section](https://doc.rust-lang.org/book/lifetimes.html#lifetime-elision) of the Rust book. "Elided lifetimes" are those lifetimes which are implicit in any code containing references. They are automatically inserted by the compiler with the three following rules:
+In fact, *all* reference types have a lifetime, but most of the time you do not have to write
+it explicitly. The rules are as follows:
 
-- Each elided lifetime in a function’s arguments becomes a distinct lifetime parameter.
-- If there is exactly one input lifetime, elided or not, that lifetime is assigned to all elided lifetimes in the return values of that function.
-- If there are multiple input lifetimes, but one of them is &self or &mut self, the lifetime of self is assigned to all elided output lifetimes.
+1. Within a function body, you never have to write a lifetime explicitly; the correct value
+   should always be inferred.
+2. Within a function *signature* (for example, in the types of its
+   arguments, or its return type), you *may* have to write a lifetime
+   explicitly. Lifetimes there use a simple defaulting scheme called
+   ["lifetime elision"](https://doc.rust-lang.org/book/lifetimes.html#lifetime-elision),
+   which consists of the following three rules:
+
+   - Each elided lifetime in a function’s arguments becomes a distinct lifetime parameter.
+   - If there is exactly one input lifetime, elided or not, that
+     lifetime is assigned to all elided lifetimes in the return values
+     of that function.
+   - If there are multiple input lifetimes, but one of them is &self
+     or &mut self, the lifetime of self is assigned to all elided
+     output lifetimes.
+3. Finally, in a `struct` or `enum` definition, all lifetimes must be explicitly declared.
 
 If these rules would result in incorrect code elsewhere, then the Rust compiler will provide errors, and you will need to define the relevant lifetimes to correct that error.
 

--- a/faq.md
+++ b/faq.md
@@ -298,20 +298,27 @@ The borrow checker applies only a few rules, which can be found in the Rust book
 
 While the rules themselves are simple, making sure your code conforms to them can be complicated. It is easy to attempt to borrow a value for longer than its lifetime, or to introduce two mutable references to the same value. The borrow checker is useful because it verifies that your code follows these rules, and helps guide corrections when the code doesn't. Many new Rust programmers struggle to satisfy the borrow checker at first, but over time become more skilled at writing memory safe code with minimal borrow checker intervention.
 
-### How do deref coercions work?
+### What is a deref coercion and hoes does it work?
 
-[Deref coercions](https://doc.rust-lang.org/book/deref-coercions.html) exist to make using Rust more ergonomic, and are implemented via the [`Deref`](https://doc.rust-lang.org/stable/std/ops/trait.Deref.html) trait, which looks like
+A [deref coercion](https://doc.rust-lang.org/book/deref-coercions.html) is a handy coercion
+that automatically converts references to pointers (e.g., `&Rc<T>` or `&Box<T>`) into references
+to their contents (e.g., `&T`). Deref coercions exist to make using Rust more ergonomic.
 
-```rust
-pub trait Deref {
-    type Target: ?Sized;
-    fn deref(&self) -> &Self::Target;
-}
-```
+The most common sorts of deref coercions are:
 
-A Deref implementation indicates that the implementing type may be converted into `Target` by a call to the `deref` function, which takes an immutable reference of a certain lifetime to the calling struct, and returns a reference of the same lifetime to the target. The `*` prefix operator is shorthand for the `deref` method.
+- `&Rc<T>` to `&T`
+- `&Box<T>` to `&T`
+- `&Arc<T>` to `&T`
+- `&Vec<T>` to `&[T]`
+- `&String` to `&str`
 
-You can see a [full list of `Deref` implementations](https://doc.rust-lang.org/stable/std/ops/trait.Deref.html#implementors) for the standard library in the documentation.
+In general though, a deref coercion permits coercion `&T` to `&U` if
+`T` can be dereferenced to `U`. Dereferencing in Rust is an
+overloadable operator controlled by the
+[`Deref`](https://doc.rust-lang.org/stable/std/ops/trait.Deref.html)
+trait. You can see a
+[full list of `Deref` implementations](https://doc.rust-lang.org/stable/std/ops/trait.Deref.html#implementors)
+for the standard library in the documentation.
 
 <h2 id="lifetimes">Lifetimes</h2>
 

--- a/faq.md
+++ b/faq.md
@@ -782,7 +782,7 @@ Converting in the other direction can be done with a `match` statement, which ma
 
 ### Why does Rust not have a stable ABI like C does, and why do I have to annotate things with extern?
 
-Committing to an ABI is a big decision that can limit potentially advantageous language changes in the future. Given that Rust only hit 1.0 in May of 2015, it is still too early to make a commitment as big as a stable ABI. This does not mean that one won't happen in the future, though.
+Committing to an ABI is a big decision that can limit potentially advantageous language changes in the future. Given that Rust only hit 1.0 in May of 2015, it is still too early to make a commitment as big as a stable ABI. This does not mean that one won't happen in the future, though. (Though C++ has managed to go for many years without specifying a stable ABI.)
 
 The `extern` keyword allows Rust to use specific ABI's, such as the well-defined C ABI, for interop with other languages.
 

--- a/faq.md
+++ b/faq.md
@@ -854,7 +854,7 @@ In Swift, `?` is used to indicate an optional value. This is already done by `Op
 
 Rust and Go have substantially different design goals. The following differences are not the only ones (which are too numerous to list), but are a few of the more important ones:
 
-- Rust is lower level than Go, comparable with C and C++. It provides access to memory management primitives that do not exist in Go (which has a garbage collector).
+- Rust is lower level than Go. For example, Rust does not require a garbage collector, whereas Go does. In general, Rust affords a level of control that is comparable to C or C++.
 - Rust's focus is on ensuring safety and efficiency while also providing high-level affordances, while Go's is on being a small, simple language which compiles quickly and can work nicely with a variety of tools.
 - Rust has strong support for generics, which Go does not.
 - Rust has strong influences from the world of functional programming, including a type system which draws from Haskell's typeclasses. Go has a simpler type system, using interfaces for basic generic programming.

--- a/faq.md
+++ b/faq.md
@@ -840,7 +840,7 @@ impl Foo {
 
 ### Does Rust have copy constructors?
 
-Not exactly. Types which implement `Copy` will do a standard C-like "shallow copy" with no extra work (similar to "plain old data" in C++). It is impossible to implement `Copy` types that require custom copy behavior. Instead, in Rust "copy constructors" are created by implementing the `Clone` trait, and explicitly calling the `clone` method. Making user-defined copy operators explicit surfaces the underlying complexity, forcing the developer to opt-in to potentially expensive operations.
+Not exactly. Types which implement `Copy` will do a standard C-like "shallow copy" with no extra work (similar to "plain old data" in C++). It is impossible to implement `Copy` types that require custom copy behavior. Instead, in Rust "copy constructors" are created by implementing the `Clone` trait, and explicitly calling the `clone` method. Making user-defined copy operators explicit surfaces the underlying complexity, making it easier for the developer to identify potentially expensive operations.
 
 ### Does Rust have move constructors?
 

--- a/faq.md
+++ b/faq.md
@@ -47,9 +47,21 @@ It is an explicit goal of Rust to be at least as fast as C++. Language decisions
 
 ### Is Rust garbage collected?
 
-No. A language that requires a GC is a language that opts into a larger, more complex runtime than Rust cares for. Rust is usable on bare metal with no extra runtime.
+No. A language that requires a GC is a language that opts into a
+larger, more complex runtime than Rust cares for. Rust is usable on
+bare metal with no extra runtime. In practice, most Rust programs rely
+on reference counting through the standard library's
+[`Rc`](http://doc.rust-lang.org/std/rc/struct.Rc.html) and
+[`Arc`](http://doc.rust-lang.org/std/sync/struct.Arc.html) types.
 
-Additionally, garbage collection is frequently a source of non-deterministic behavior. Rust provides tools to make using third-party garbage collectors [possible](http://manishearth.github.io/blog/2015/09/01/designing-a-gc-in-rust/), but it is not part of the language as provided.
+We are however investigating *optional* garbage collection as a future
+extension. The goal is to enable smooth integration with
+garbage-collected runtimes, such as those offered by the
+[Spidermonkey](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey)
+and [V8](https://developers.google.com/v8/?hl=en) JavaScript engines.
+Finally, some people have investigated implementing
+[pure Rust garbage collectors](http://manishearth.github.io/blog/2015/09/01/designing-a-gc-in-rust/)
+without compiler support.
 
 ### Why is my program slow?
 


### PR DESCRIPTION
Here are some edits I made while reading over the FAQ. Some of these overlap with what @aturon did, and some of them may or may not be improvements in any case. :)

Perhaps the most important edit is the one to the question C++ rvalue references. I tried to clarify how they are similar in purpose but also quite different from Rust's move semantics and highlight the differences. 

Feedback more than welcome of course!

cc @brson @AndrewBrinker

(also, these commits were not rebased against the latest branch...)
